### PR TITLE
解决传入语言标签大小写不一致时的异常

### DIFF
--- a/src/dotnetCampus.Localizations.Analyzer/Assets/Templates/Localization.g.cs
+++ b/src/dotnetCampus.Localizations.Analyzer/Assets/Templates/Localization.g.cs
@@ -29,11 +29,12 @@ partial class Localization
     /// <param name="ietfLanguageTag">IETF 语言标签。</param>
     private static LocalizedValues CreateLocalizedValues(string ietfLanguageTag)
     {
-        if (_default is { } @default && ietfLanguageTag == "DEFAULT_IETF_LANGUAGE_TAG")
+        var lowerTag = ietfLanguageTag.ToLowerInvariant();
+        if (_default is { } @default && lowerTag == "DEFAULT_IETF_LANGUAGE_TAG")
         {
             return @default;
         }
-        return ietfLanguageTag switch
+        return lowerTag switch
         {
             // <FLAG>
             "en" => new LocalizedValues(null!),


### PR DESCRIPTION
关于大小写的原则：

1. 所有公开出来给开发者们用的标签，原封不动还原开发者们指定的大小写；
2. 内部，全部小写。