### PR TITLE
使用静态构造函数解决数组初始化时机太晚的问题；找不到fallback语言时返回默认语言；优化源代码生成器的替换逻辑；

### DIFF
--- a/src/dotnetCampus.Localizations.Analyzer/Assets/Templates/ImmutableLocalization.g.cs
+++ b/src/dotnetCampus.Localizations.Analyzer/Assets/Templates/ImmutableLocalization.g.cs
@@ -17,8 +17,13 @@ partial class ImmutableLocalization
     /// <summary>
     /// 当前的不可变本地化字符串集实例。
     /// </summary>
-    private static ImmutableLocalizedValues _current = GetOrCreateLocalizedValues("CURRENT_IETF_LANGUAGE_TAG");
+    private static ImmutableLocalizedValues _current;
 
+    static ImmutableLocalization()
+    {
+        _current = GetOrCreateLocalizedValues("CURRENT_IETF_LANGUAGE_TAG");
+    }
+    
     /// <summary>
     /// 获取默认的本地化字符串集。
     /// </summary>
@@ -123,9 +128,7 @@ partial class ImmutableLocalization
         {
             return provider;
         }
-        throw new global::System.ArgumentException(
-            $"The language tag {languageTag} is not supported. Supported language tags are: {string.Join(", ", SupportedLanguageTags)}.",
-            nameof(languageTag));
+        return _default.LocalizedStringProvider;
     }
 
     /// <summary>

--- a/src/dotnetCampus.Localizations.Analyzer/Assets/Templates/NotifiableLocalization.g.cs
+++ b/src/dotnetCampus.Localizations.Analyzer/Assets/Templates/NotifiableLocalization.g.cs
@@ -18,8 +18,26 @@ partial class NotifiableLocalization
     /// 当前的可通知本地化字符串集实例。
     /// 此实例支持属性变更通知，适用于UI绑定场景。
     /// </summary>
-    private static NotifiableLocalizedValues _current = new NotifiableLocalizedValues(CreateLocalizedStringProvider("CURRENT_IETF_LANGUAGE_TAG"));
+    private static NotifiableLocalizedValues _current;
 
+    static NotifiableLocalization()
+    {
+        _current = new NotifiableLocalizedValues(CreateLocalizedStringProvider("CURRENT_IETF_LANGUAGE_TAG"));
+    }
+    
+    /// <summary>
+    /// 获取支持的语言标签。
+    /// </summary>
+    /// <remarks>
+    /// 由于项目中可以设置 LocalizationSupportsNonIetfLanguageTag 属性，所以不一定是 IETF 语言标签。
+    /// </remarks>
+    public static System.Collections.Immutable.ImmutableArray<string> SupportedLanguageTags { get; } =
+    [
+        // <FLAG2>
+        "en",
+        // </FLAG2>
+    ];
+    
     /// <summary>
     /// 获取默认的本地化字符串集。
     /// </summary>
@@ -36,19 +54,6 @@ partial class NotifiableLocalization
     /// 会通过 INotifyPropertyChanged 接口通知所有绑定的属性已变更。
     /// </remarks>
     public static ILocalizedValues Current => _current;
-
-    /// <summary>
-    /// 获取支持的语言标签。
-    /// </summary>
-    /// <remarks>
-    /// 由于项目中可以设置 LocalizationSupportsNonIetfLanguageTag 属性，所以不一定是 IETF 语言标签。
-    /// </remarks>
-    public static System.Collections.Immutable.ImmutableArray<string> SupportedLanguageTags { get; } =
-    [
-        // <FLAG2>
-        "en",
-        // </FLAG2>
-    ];
 
     /// <summary>
     /// 设置当前的本地化字符串集。
@@ -96,9 +101,7 @@ partial class NotifiableLocalization
         {
             return provider;
         }
-        throw new global::System.ArgumentException(
-            $"The language tag {languageTag} is not supported. Supported language tags are: {string.Join(", ", SupportedLanguageTags)}.",
-            nameof(languageTag));
+        return _default.LocalizedStringProvider;
     }
 
     /// <summary>

--- a/src/dotnetCampus.Localizations.Analyzer/Generators/LocalizationTypeGenerator.cs
+++ b/src/dotnetCampus.Localizations.Analyzer/Generators/LocalizationTypeGenerator.cs
@@ -89,33 +89,13 @@ public class LocalizationTypeGenerator : IIncrementalGenerator
 """;
     }
 
-    private static string ReplaceNamespaceAndTypeName(string sourceText, string rootNamespace, string? typeName)
+    private static string ReplaceNamespaceAndTypeName(string sourceText, string rootNamespace, string typeName)
     {
-        var sourceSpan = sourceText.AsSpan();
-
-        var namespaceKeywordIndex = sourceText.IndexOf("namespace", StringComparison.Ordinal);
-        var namespaceStartIndex = namespaceKeywordIndex + "namespace".Length + 1;
-        var namespaceEndIndex = sourceText.IndexOf(";", namespaceStartIndex, StringComparison.Ordinal);
-        var typeKeywordMatch = TemplateRegexes.TypeRegex.Match(sourceText);
-
-        if (typeName is null || !typeKeywordMatch.Success)
-        {
-            return string.Concat(
-                sourceSpan.Slice(0, namespaceStartIndex).ToString(),
-                rootNamespace,
-                sourceSpan.Slice(namespaceEndIndex, sourceSpan.Length - namespaceEndIndex).ToString()
-            );
-        }
-
-        var typeNameIndex = typeKeywordMatch.Groups[1].Index;
-        var typeNameLength = typeKeywordMatch.Groups[1].Length;
-
-        return string.Concat(
-            sourceSpan.Slice(0, namespaceStartIndex).ToString(),
-            rootNamespace,
-            sourceSpan.Slice(namespaceEndIndex, typeNameIndex - namespaceEndIndex).ToString(),
-            typeName,
-            sourceSpan.Slice(typeNameIndex + typeNameLength, sourceSpan.Length - typeNameIndex - typeNameLength).ToString()
-        );
+        return sourceText
+            .Replace("namespace dotnetCampus.Localizations.Assets.Templates;", $"namespace {rootNamespace};")
+            .Replace("partial class ImmutableLocalization", $"partial class {typeName}")
+            .Replace("partial class NotifiableLocalization", $"partial class {typeName}")
+            .Replace("static ImmutableLocalization()", $"static {typeName}()")
+            .Replace("static NotifiableLocalization()", $"static {typeName}()");
     }
 }


### PR DESCRIPTION
使用静态构造函数解决数组初始化时机太晚的问题；
找不到fallback语言时返回默认语言；
优化源代码生成器的替换逻辑；