### PR TITLE
尝试修复生成的代码抛出的异常找不到命名空间

### DIFF
--- a/samples/LocalizationSample/LocalizationSample.csproj
+++ b/samples/LocalizationSample/LocalizationSample.csproj
@@ -6,6 +6,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
     <LocalizationSupportsNonIetfLanguageTag>false</LocalizationSupportsNonIetfLanguageTag>
+    <ImplicitUsings>disable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/LocalizationSample/Program.cs
+++ b/samples/LocalizationSample/Program.cs
@@ -1,4 +1,6 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
+using System.Threading.Tasks;
 using dotnetCampus.Localizations;
 
 namespace LocalizationSample;

--- a/src/dotnetCampus.Localizations.Analyzer/Assets/Templates/ImmutableLocalization.g.cs
+++ b/src/dotnetCampus.Localizations.Analyzer/Assets/Templates/ImmutableLocalization.g.cs
@@ -1,5 +1,7 @@
 #nullable enable
 using global::dotnetCampus.Localizations;
+using StringComparison = global::System.StringComparison;
+using System;
 
 namespace dotnetCampus.Localizations.Assets.Templates;
 

--- a/src/dotnetCampus.Localizations.Analyzer/Assets/Templates/ImmutableLocalizedValues.g.cs
+++ b/src/dotnetCampus.Localizations.Analyzer/Assets/Templates/ImmutableLocalizedValues.g.cs
@@ -3,6 +3,8 @@ using ILocalizedStringProvider = global::dotnetCampus.Localizations.ILocalizedSt
 using INotifyPropertyChanged = global::System.ComponentModel.INotifyPropertyChanged;
 using LocalizedString = global::dotnetCampus.Localizations.LocalizedString;
 using PropertyChangedEventHandler = global::System.ComponentModel.PropertyChangedEventHandler;
+using StringComparison = global::System.StringComparison;
+using System;
 
 namespace dotnetCampus.Localizations.Assets.Templates;
 

--- a/src/dotnetCampus.Localizations.Analyzer/Assets/Templates/NotifiableLocalizedValues.g.cs
+++ b/src/dotnetCampus.Localizations.Analyzer/Assets/Templates/NotifiableLocalizedValues.g.cs
@@ -4,6 +4,8 @@ using INotifyPropertyChanged = global::System.ComponentModel.INotifyPropertyChan
 using LocalizedString = global::dotnetCampus.Localizations.LocalizedString;
 using PropertyChangedEventArgs = global::System.ComponentModel.PropertyChangedEventArgs;
 using PropertyChangedEventHandler = global::System.ComponentModel.PropertyChangedEventHandler;
+using System;
+using ArgumentNullException = global::System.ArgumentNullException;
 
 namespace dotnetCampus.Localizations.Assets.Templates;
 


### PR DESCRIPTION
![](https://github.com/user-attachments/assets/45ceda63-36f5-4ada-8902-43c5310a18ef)

```csharp
#pragma warning disable CS1998
    internal async global::System.Threading.Tasks.ValueTask SetProvider(ILocalizedStringProvider newProvider)
#pragma warning restore CS1998
    {
        if (newProvider is null)
        {
            throw new ArgumentNullException(nameof(newProvider));
        }
    ...
```

这里的 ArgumentNullException 找不到命名空间