### PR TITLE
适配 Avalonia/Uno/WPF 等的 UI 绑定

### DIFF
--- a/src/dotnetCampus.Localizations.Analyzer/Assets/Templates/ILocalizedValues.g.cs
+++ b/src/dotnetCampus.Localizations.Analyzer/Assets/Templates/ILocalizedValues.g.cs
@@ -6,7 +6,7 @@ using LocalizedString = global::dotnetCampus.Localizations.LocalizedString;
 namespace dotnetCampus.Localizations.Assets.Templates;
 
 [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-public partial interface ILocalizedValues
+public partial interface ILocalizedValues : ILocalizedStringProvider
 {
     // <FLAG>
     // LocalizedString A1 { get; }

--- a/src/dotnetCampus.Localizations.Analyzer/Assets/Templates/ImmutableLocalization.g.cs
+++ b/src/dotnetCampus.Localizations.Analyzer/Assets/Templates/ImmutableLocalization.g.cs
@@ -25,7 +25,7 @@ partial class ImmutableLocalization
     {
         _current = GetOrCreateLocalizedValues("CURRENT_IETF_LANGUAGE_TAG");
     }
-    
+
     /// <summary>
     /// 获取默认的本地化字符串集。
     /// </summary>

--- a/src/dotnetCampus.Localizations.Analyzer/Assets/Templates/ImmutableLocalizedValues.g.cs
+++ b/src/dotnetCampus.Localizations.Analyzer/Assets/Templates/ImmutableLocalizedValues.g.cs
@@ -17,6 +17,10 @@ internal sealed class ImmutableLocalizedValues(ILocalizedStringProvider provider
     /// </summary>
     public ILocalizedStringProvider LocalizedStringProvider => provider;
 
+    public string IetfLanguageTag => LocalizedStringProvider.IetfLanguageTag;
+
+    public string this[string key] => LocalizedStringProvider[key];
+
     // <FLAG>
     // 在此处生成数状结构当前节点的本地化值。
     // public LocalizedString A1 => provider.Get0("A.A1");

--- a/src/dotnetCampus.Localizations.Analyzer/Assets/Templates/NotifiableLocalizedValues.g.cs
+++ b/src/dotnetCampus.Localizations.Analyzer/Assets/Templates/NotifiableLocalizedValues.g.cs
@@ -18,6 +18,10 @@ internal sealed class NotifiableLocalizedValues(ILocalizedStringProvider provide
     /// </summary>
     public ILocalizedStringProvider LocalizedStringProvider { get; private set; } = provider;
 
+    public string IetfLanguageTag => LocalizedStringProvider.IetfLanguageTag;
+
+    public string this[string key] => LocalizedStringProvider[key];
+
     // <FLAG3>
     /// <summary>
     /// 在不改变 <see cref="LocalizedStringProvider"/> 实例的情况下，设置新的本地化字符串提供器，并通知所有的属性的变更。

--- a/src/dotnetCampus.Localizations.Analyzer/Generators/CodeTransforming/LocalizationCodeTransformer.cs
+++ b/src/dotnetCampus.Localizations.Analyzer/Generators/CodeTransforming/LocalizationCodeTransformer.cs
@@ -29,7 +29,7 @@ public class LocalizationCodeTransformer
     /// 创建 <see cref="LocalizationCodeTransformer"/> 的新实例。
     /// </summary>
     /// <param name="fileModels">读取出来的所有语言项。</param>
-    public LocalizationCodeTransformer(ImmutableArray<LocalizationFileModel> fileModels)
+    public LocalizationCodeTransformer(IReadOnlyList<LocalizationFileModel> fileModels)
     {
         LocalizationItems =
         [

--- a/src/dotnetCampus.Localizations.Analyzer/Generators/LocalizationTypeGenerator.cs
+++ b/src/dotnetCampus.Localizations.Analyzer/Generators/LocalizationTypeGenerator.cs
@@ -74,7 +74,7 @@ public class LocalizationTypeGenerator : IIncrementalGenerator
 {string.Join("\n", languageTags.Select(x => $"        \"{x}\","))}
 """;
 
-    private string GenerateCreateLocalizedValues(string defaultIetfTag, IReadOnlyDictionary<string, ImmutableArray<LocalizationFileModel>> models) => $"""
+    private string GenerateCreateLocalizedValues(string defaultIetfTag, IReadOnlyDictionary<string, IReadOnlyList<LocalizationFileModel>> models) => $"""
 {string.Join("\n", models.Select(x => ConvertModelToPatternMatch(defaultIetfTag, x.Key)))}
 """;
 

--- a/src/dotnetCampus.Localizations.Analyzer/Generators/ModelProviding/IetfLanguageTagExtensions.cs
+++ b/src/dotnetCampus.Localizations.Analyzer/Generators/ModelProviding/IetfLanguageTagExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Immutable;
-using System.Globalization;
+﻿using System.Globalization;
 
 namespace dotnetCampus.Localizations.Generators.ModelProviding;
 
@@ -47,7 +46,7 @@ public static class IetfLanguageTagExtensions
     /// <param name="models">要分组的 <see cref="LocalizationFileModel"/> 集合。</param>
     /// <param name="supportsNonIetfLanguageTag">是否支持非 IETF 语言标签。</param>
     /// <returns>枚举的每一项都是一个元组，包含 IETF 语言标签和对应的 <see cref="LocalizationFileModel"/> 集合。</returns>
-    public static IEnumerable<(string IetfLanguageTag, ImmutableArray<LocalizationFileModel> Models)> GroupByIetfLanguageTag(
+    public static IEnumerable<(string IetfLanguageTag, IReadOnlyList<LocalizationFileModel> Models)> GroupByIetfLanguageTag(
         this IEnumerable<LocalizationFileModel> models, bool supportsNonIetfLanguageTag)
     {
         var groups = new Dictionary<string, List<LocalizationFileModel>>(StringComparer.OrdinalIgnoreCase);

--- a/src/dotnetCampus.Localizations/Helpers/LocalizationHelper.cs
+++ b/src/dotnetCampus.Localizations/Helpers/LocalizationHelper.cs
@@ -1,4 +1,3 @@
-using System.Collections.Immutable;
 using System.Globalization;
 
 namespace dotnetCampus.Localizations.Helpers;
@@ -23,7 +22,7 @@ public static class LocalizationHelper
     /// 获取用户首选的语言列表。
     /// </summary>
     /// <returns>用户首选的语言列表。</returns>
-    public static ImmutableArray<string> GetUserPreferredLanguages()
+    public static IReadOnlyList<string> GetUserPreferredLanguages()
     {
         // if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         // {

--- a/src/dotnetCampus.Localizations/ILocalizedStringProvider.cs
+++ b/src/dotnetCampus.Localizations/ILocalizedStringProvider.cs
@@ -14,6 +14,6 @@ public interface ILocalizedStringProvider
     /// 获取指定键的本地化字符串。
     /// </summary>
     /// <param name="key">要获取的本地化字符串的键。</param>
-    /// <returns>一个无参的本地化字符串。</returns>
+    /// <returns>一个本地化字符串。如果字符串包含占位符，则返回的字符串会包含形如 "{0}" "{1}" 这样的占位符用来格式化。</returns>
     string this[string key] { get; }
 }

--- a/src/dotnetCampus.Localizations/LocalizedString.cs
+++ b/src/dotnetCampus.Localizations/LocalizedString.cs
@@ -28,7 +28,7 @@ public readonly record struct LocalizedString
     /// <remarks>
     /// 只有无参本地化字符串具有 <see cref="Value"/> 属性，可用于不可控的弱类型代码中，要求必须传入 string 实例时使用（如 XAML 绑定）。
     /// </remarks>
-    private string Value { get; }
+    public string Value { get; }
 
     /// <summary>
     /// 隐式转换为字符串。

--- a/src/dotnetCampus.Localizations/LocalizedString.cs
+++ b/src/dotnetCampus.Localizations/LocalizedString.cs
@@ -6,11 +6,10 @@ namespace dotnetCampus.Localizations;
 /// <summary>
 /// 表示一个本地化字符串，可隐式转换为字符串。
 /// </summary>
-[DebuggerDisplay("{_key} = \"{_value}\"")]
+[DebuggerDisplay("{_key} = \"{Value}\"")]
 public readonly record struct LocalizedString
 {
     private readonly string _key;
-    private readonly string _value;
 
     /// <summary>
     /// 初始化一个新的本地化字符串实例。
@@ -20,20 +19,28 @@ public readonly record struct LocalizedString
     public LocalizedString(string key, string value)
     {
         _key = key;
-        _value = value;
+        Value = value;
     }
+
+    /// <summary>
+    /// 获取多语言值。
+    /// </summary>
+    /// <remarks>
+    /// 只有无参本地化字符串具有 <see cref="Value"/> 属性，可用于不可控的弱类型代码中，要求必须传入 string 实例时使用（如 XAML 绑定）。
+    /// </remarks>
+    private string Value { get; }
 
     /// <summary>
     /// 隐式转换为字符串。
     /// </summary>
     /// <param name="localizedString">要转换的本地化字符串。</param>
-    public static implicit operator string(LocalizedString localizedString) => localizedString._value;
+    public static implicit operator string(LocalizedString localizedString) => localizedString.Value;
 
     /// <summary>
     /// 将本地化字符串转换为字符串。
     /// </summary>
     /// <returns>转换的字符串。</returns>
-    public override string ToString() => _value;
+    public override string ToString() => Value;
 }
 
 /// <summary>

--- a/src/dotnetCampus.SourceLocalizations.PrivateGenerator/Generators/IetfLanguageTagsGenerator.cs
+++ b/src/dotnetCampus.SourceLocalizations.PrivateGenerator/Generators/IetfLanguageTagsGenerator.cs
@@ -43,7 +43,7 @@ partial class IetfLanguageTags
     /// <summary>
     /// 包含所有 IETF 语言标签字符串常量的不可变哈希集合。
     /// </summary>
-    public static global::System.Collections.Immutable.ImmutableHashSet<string> Set { get; } = 
+    public static global::System.Collections.Frozen.FrozenSet<string> Set { get; } = 
     [
 {{string.Join("\n", GenerateDictionaryTagKeyValues(allCultures))}}
     ];


### PR DESCRIPTION
1. 无参的本地化字符串，允许直接通过 `Value` 属性获取字符串类型的值，用于绑定（如果没有这个属性，那么当 UI 属性非 `string` 时，两种类型之间不存在转换方法，导致无法识别属性的值：例如 LocalizedString 无法转换为 Uri 类型，导致绑定失败）
2. 允许业务代码使用拼接字符串来获取本地化字符串，形如 `Lang.Current[$"Xxx.{Xxx}"]`，否则有些业务确实很难写
3. 其他无关痛痒的优化