### PR TITLE
Remove `System.Collections.Immutable` dependency

### DIFF
--- a/src/dotnetCampus.Localizations/dotnetCampus.Localizations.csproj
+++ b/src/dotnetCampus.Localizations/dotnetCampus.Localizations.csproj
@@ -35,7 +35,6 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="Samboy063.Tomlet" Version="5.3.1" ReferenceOutputAssembly="false" PrivateAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="YamlDotNet" Version="15.1.4" ReferenceOutputAssembly="false" PrivateAssets="all" GeneratePathProperty="true" />
-    <PackageReference Include="System.Collections.Immutable" Version="9.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dotnetCampus.SourceLocalizations.PrivateGenerator/Generators/IetfLanguageTagsGenerator.cs
+++ b/src/dotnetCampus.SourceLocalizations.PrivateGenerator/Generators/IetfLanguageTagsGenerator.cs
@@ -43,7 +43,7 @@ partial class IetfLanguageTags
     /// <summary>
     /// 包含所有 IETF 语言标签字符串常量的不可变哈希集合。
     /// </summary>
-    public static global::System.Collections.Frozen.FrozenSet<string> Set { get; } = 
+    public static global::System.Collections.Generic.HashSet<string> Set { get; } = 
     [
 {{string.Join("\n", GenerateDictionaryTagKeyValues(allCultures))}}
     ];


### PR DESCRIPTION
移除 System.Collections.Immutable 依赖，因为实际上没有任何地方是真正需要它的。移除后，目标项目将可以支持更老的 net6.0